### PR TITLE
Add compatibility to main page

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -134,8 +134,12 @@ export const updateUser = async ({ user }: { user: InsertUser }) => {
 
 export const handleNewUsername = async ({ username, redirectPath }: { username: string; redirectPath?: string }) => {
   const user = await getUser({ username })
-  if (user && redirectPath) {
-    redirect(redirectPath)
+  if (user) {
+    if (redirectPath) {
+      redirect(redirectPath)
+    } else {
+      return { error: false, found: true }
+    }
   }
 
   let { data, error } = await fetchUserData({ screenName: username })
@@ -544,7 +548,13 @@ export const getOrCreatePair = async ({ usernames, shouldRedirect }: { usernames
 
   const existingPair = await getPair({ usernames })
 
-  if (existingPair) return existingPair
+  if (existingPair) {
+    if (shouldRedirect) {
+      redirect(`/${usernames[0]}/${usernames[1]}`)
+    } else {
+      return existingPair
+    }
+  }
 
   return await createPair({ usernames, shouldRedirect })
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,10 @@
 import { Suspense } from 'react'
 import Link from 'next/link'
-import { PiBrain, PiGithubLogo } from 'react-icons/pi'
+import { PiBrain, PiGithubLogo, PiXLogo } from 'react-icons/pi'
 
 import Quote from '@/app/quote'
 import WordwareLogo from '@/components/logo'
+import NewPairFormBothNames from '@/components/new-pair-form-both-names'
 import NewUsernameForm from '@/components/new-username-form'
 import PHButton from '@/components/ph-button'
 import { Button } from '@/components/ui/button'
@@ -17,7 +18,7 @@ const Page = () => {
     <section>
       <div className="flex flex-col md:flex-row">
         <div className="relative flex min-h-screen flex-col justify-center bg-[#F9FAFB] p-8 sm:p-12 md:w-1/2 md:p-16 lg:p-24">
-          <h2 className="flex items-center justify-start gap-4">
+          <h2 className="flex items-center justify-start gap-4 pb-8">
             Powered by{' '}
             <a
               href="https://wordware.ai/"
@@ -31,30 +32,55 @@ const Page = () => {
           <div className="grow" />
 
           <div>
-            <h1 className="mb-8 text-4xl md:text-5xl 2xl:text-6xl">
-              discover your <br />
-              <span
-                className="bg-clip-text text-transparent"
-                style={{ backgroundColor: '#CB9F9F' }}>
-                {' '}
-                twitter{' '}
-              </span>
-              personality
-            </h1>
-            <p className="text-sm text-red-900">
-              We&apos;re currently experiencing high demand.
-              <br />
-              Thank you for your patience as we work to accommodate all users.
-            </p>
+            <div>
+              <h1 className="mb-8 text-4xl md:text-5xl 2xl:text-6xl">
+                discover your <br />
+                <span
+                  className="bg-clip-text text-transparent"
+                  style={{ backgroundColor: '#CB9F9F' }}>
+                  {' '}
+                  twitter{' '}
+                </span>
+                personality 🔥
+              </h1>
 
-            <div className="mb-8 flex items-center pt-2">
-              <Suspense>
-                <NewUsernameForm />
-              </Suspense>
+              <div className="mb-8 flex w-full flex-col pt-2">
+                <div className="flex w-full items-center">
+                  <Suspense>
+                    <NewUsernameForm />
+                  </Suspense>
+                </div>
+              </div>
+            </div>
+            <div className="pt-8">
+              <h1 className="mb-8 text-4xl md:text-5xl 2xl:text-6xl">
+                check your{' '}
+                <span className="inline-flex items-center align-middle">
+                  <PiXLogo />
+                  <PiXLogo />
+                  <PiXLogo />
+                </span>
+                <br />
+                <span
+                  className="bg-clip-text text-transparent"
+                  style={{ backgroundColor: '#6DB1BF' }}>
+                  {' '}
+                  compatibility
+                </span>{' '}
+                💞
+              </h1>
+
+              <div className="mb-8 flex w-full flex-col pt-2">
+                <div className="flex w-full items-center">
+                  <Suspense>
+                    <NewPairFormBothNames />
+                  </Suspense>
+                </div>
+              </div>
             </div>
 
             <div className="mb-8 pt-8 text-base 2xl:text-lg">
-              This is an AI Agent built with{' '}
+              These are AI Agents built with{' '}
               <a
                 className="font-medium underline-offset-4 hover:underline"
                 target="_blank"
@@ -63,10 +89,10 @@ const Page = () => {
               </a>
               , it will:
               <ul className="mt-2 list-disc space-y-1 pl-8">
-                <li>find your twitter account online</li>
-                <li>an AI agent will read your tweets</li>
+                <li>find Twitter accounts online</li>
+                <li>will read your profile and tweets</li>
                 <li>then it will use Large Language Models - like the ones in ChatGPT - to analyse your personality</li>
-                <li>finally, it&apos;ll create a website with the analysis</li>
+                <li>finally, it&apos;ll create a website with the analysis of your personality or compatibility</li>
               </ul>
             </div>
           </div>

--- a/src/components/analysis/pair-component.tsx
+++ b/src/components/analysis/pair-component.tsx
@@ -25,7 +25,7 @@ const PairComponent = ({ users, pair }: { users: SelectUser[]; pair: SelectPair 
             steps={user1Steps}
             result={user1Result}
             disableAnalysis={true}
-            userUnlocked={user1.unlocked || false}
+            userUnlocked={pair.unlocked || false}
           />
         </div>
         <div className="w-1/2">
@@ -33,7 +33,7 @@ const PairComponent = ({ users, pair }: { users: SelectUser[]; pair: SelectPair 
             steps={user2Steps}
             result={user2Result}
             disableAnalysis={true}
-            userUnlocked={user2.unlocked || false}
+            userUnlocked={pair.unlocked || false}
           />
         </div>
       </div>

--- a/src/components/new-pair-form-both-names.tsx
+++ b/src/components/new-pair-form-both-names.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import * as React from 'react'
+import { usePathname } from 'next/navigation'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { PiSparkle, PiSpinner } from 'react-icons/pi'
+import { toast } from 'sonner'
+import { z } from 'zod'
+
+import { getOrCreatePair, handleNewUsername } from '@/actions/actions'
+import { Button } from '@/components/ui/button'
+import { Form, FormControl, FormField, FormItem } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { cleanUsername, cn } from '@/lib/utils'
+
+const formSchema = z.object({
+  username1: z.string().min(3).max(50),
+  username2: z.string().min(3).max(50),
+})
+
+const NewPairFormBothNames = () => {
+  const pathname = usePathname()
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      username1: '',
+      username2: '',
+    },
+  })
+
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    const cleanedUsername1 = cleanUsername(values.username1)
+    const cleanedUsername2 = cleanUsername(values.username2)
+    if (cleanedUsername1.toLowerCase() === cleanedUsername2.toLowerCase()) {
+      toast.error('You cannot pair with yourself')
+      return
+    }
+    const response = await handleNewUsername({
+      username: cleanedUsername1,
+      redirectPath: `${pathname}/${cleanedUsername1}`,
+    })
+
+    if (response?.error) {
+      toast.error(response.error)
+      return
+    }
+    await getOrCreatePair({ usernames: [cleanedUsername1, cleanedUsername2], shouldRedirect: true })
+  }
+
+  return (
+    <div className="w-full gap-4">
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="flex w-full min-w-0 max-w-sm">
+          <div className="flex w-full flex-col">
+            <FormField
+              control={form.control}
+              name="username1"
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <div className="flex items-center">
+                      <Input
+                        disabled={form.formState.isSubmitting}
+                        className="w-full rounded-b-none rounded-t-sm border-blue-500"
+                        placeholder="@username"
+                        {...field}
+                      />
+                    </div>
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="username2"
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <div className="flex items-center">
+                      <Input
+                        disabled={form.formState.isSubmitting}
+                        className="w-full rounded-none border-t-0 border-blue-500"
+                        placeholder="@username"
+                        {...field}
+                      />
+                    </div>
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+            <Button
+              disabled={form.formState.isSubmitting}
+              type="submit"
+              className="w-full gap-2 rounded-b-sm rounded-t-none bg-blue-500 hover:bg-blue-600">
+              <PiSparkle />
+              Check Compatibility
+            </Button>
+            {form.formState.errors.username1 && (
+              <p className="mt-2 text-sm font-medium text-destructive">Error with first username: {form.formState.errors.username1?.message}</p>
+            )}
+            {form.formState.errors.username2 && (
+              <p className="mt-2 text-sm font-medium text-destructive">Error with second username: {form.formState.errors.username2?.message}</p>
+            )}
+          </div>
+        </form>
+      </Form>
+      {/* Display loading spinner when form is submitting or submission is successful */}
+      {form.formState.isSubmitting && (
+        <div className="flex items-center gap-2 text-sm">
+          <PiSpinner className="animate-spin" />
+          Checking compatibility...
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default NewPairFormBothNames

--- a/src/components/new-pair-form-both-names.tsx
+++ b/src/components/new-pair-form-both-names.tsx
@@ -20,8 +20,6 @@ const formSchema = z.object({
 })
 
 const NewPairFormBothNames = () => {
-  const pathname = usePathname()
-
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -39,13 +37,24 @@ const NewPairFormBothNames = () => {
     }
     const response = await handleNewUsername({
       username: cleanedUsername1,
-      redirectPath: `${pathname}/${cleanedUsername1}`,
     })
+    console.log('Response1', response)
 
     if (response?.error) {
       toast.error(response.error)
       return
     }
+
+    const response2 = await handleNewUsername({
+      username: cleanedUsername2,
+    })
+    console.log('Response2', response2)
+
+    if (response2?.error) {
+      toast.error(response2.error)
+      return
+    }
+
     await getOrCreatePair({ usernames: [cleanedUsername1, cleanedUsername2], shouldRedirect: true })
   }
 
@@ -110,7 +119,7 @@ const NewPairFormBothNames = () => {
       </Form>
       {/* Display loading spinner when form is submitting or submission is successful */}
       {form.formState.isSubmitting && (
-        <div className="flex items-center gap-2 text-sm">
+        <div className="flex items-center gap-2 pt-4 text-sm">
           <PiSpinner className="animate-spin" />
           Checking compatibility...
         </div>

--- a/src/components/new-pair-form-both-names.tsx
+++ b/src/components/new-pair-form-both-names.tsx
@@ -12,7 +12,7 @@ import { getOrCreatePair, handleNewUsername } from '@/actions/actions'
 import { Button } from '@/components/ui/button'
 import { Form, FormControl, FormField, FormItem } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
-import { cleanUsername, cn } from '@/lib/utils'
+import { cleanUsername } from '@/lib/utils'
 
 const formSchema = z.object({
   username1: z.string().min(3).max(50),

--- a/src/components/new-pair-form-both-names.tsx
+++ b/src/components/new-pair-form-both-names.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import * as React from 'react'
-import { usePathname } from 'next/navigation'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import { PiSparkle, PiSpinner } from 'react-icons/pi'

--- a/src/hooks/compatibility-analysis.tsx
+++ b/src/hooks/compatibility-analysis.tsx
@@ -26,7 +26,7 @@ export const useCompatibilityAnalysis = (user1: SelectUser, user2: SelectUser, p
 
   useEffect(() => {
     if (!pair.unlocked) return
-    if (user1Steps.tweetScrapeCompleted && user2Steps.tweetScrapeCompleted && !steps.compatibilityAnalysisStarted) {
+    if (user1Steps.tweetScrapeCompleted && user2Steps.tweetScrapeCompleted && !steps.compatibilityAnalysisCompleted) {
       if (effectRan.current) return
       effectRan.current = true
       ;(async () => {
@@ -39,7 +39,10 @@ export const useCompatibilityAnalysis = (user1: SelectUser, user2: SelectUser, p
   }, [user1.username, user2.username, user1Steps, user2Steps, steps.compatibilityAnalysisStarted, pair.unlocked])
 
   const handleCompatibilityAnalysis = async (props: { usernames: string[]; full: boolean }) => {
-    if (steps.compatibilityAnalysisStarted) return
+    if (steps.compatibilityAnalysisStarted && Date.now() - pair.wordwareStartedTime.getTime() < 2 * 60 * 1000) {
+      console.log('Not starting compatibility analysis', steps.compatibilityAnalysisStarted, Date.now() - pair.wordwareStartedTime.getTime())
+      return
+    }
     const response = await fetch('/api/wordware/pair', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/src/hooks/compatibility-analysis.tsx
+++ b/src/hooks/compatibility-analysis.tsx
@@ -13,8 +13,8 @@ export type CompatibilitySteps = {
 }
 
 export const useCompatibilityAnalysis = (user1: SelectUser, user2: SelectUser, pair: SelectPair) => {
-  const { steps: user1Steps, result: user1Result } = useTwitterAnalysis(user1, true)
-  const { steps: user2Steps, result: user2Result } = useTwitterAnalysis(user2, true)
+  const { steps: user1Steps, result: user1Result } = useTwitterAnalysis(user1, true, pair.unlocked || false)
+  const { steps: user2Steps, result: user2Result } = useTwitterAnalysis(user2, true, pair.unlocked || false)
   const [compatibilityResult, setCompatibilityResult] = useState<CompatibilityAnalysis | undefined>((pair.analysis as CompatibilityAnalysis) || undefined)
   const [steps, setSteps] = useState<CompatibilitySteps>({
     user1Steps,
@@ -75,5 +75,13 @@ export const useCompatibilityAnalysis = (user1: SelectUser, user2: SelectUser, p
     }
   }
 
-  return { steps, user1Steps, user1Result, user2Steps, user2Result, compatibilityResult, unlocked: pair.unlocked || false }
+  return {
+    steps,
+    user1Steps,
+    user1Result,
+    user2Steps,
+    user2Result,
+    compatibilityResult,
+    unlocked: pair.unlocked || false,
+  }
 }

--- a/src/hooks/twitter-analysis.tsx
+++ b/src/hooks/twitter-analysis.tsx
@@ -24,7 +24,7 @@ export type Steps = {
  * @returns {Object} An object containing the analysis steps and results.
  */
 
-export const useTwitterAnalysis = (user: SelectUser, disableAnalysis: boolean = false) => {
+export const useTwitterAnalysis = (user: SelectUser, disableAnalysis: boolean = false, forceScrape: boolean = false) => {
   const [steps, setSteps] = useState<Steps>(initializeSteps(user))
   const [result, setResult] = useState<TwitterAnalysis | undefined>((user.analysis as TwitterAnalysis) || undefined)
   const effectRan = useRef(false)
@@ -107,8 +107,11 @@ export const useTwitterAnalysis = (user: SelectUser, disableAnalysis: boolean = 
   }
 
   const shouldRunTweetScrape = (user: SelectUser): boolean => {
-    const unlockedCheck = PAYWALL ? user.unlocked || false : true
-    return unlockedCheck && (!user.tweetScrapeStarted || (!user.tweetScrapeCompleted && Date.now() - user.tweetScrapeStartedTime.getTime() > 1 * 60 * 1000))
+    const isUnlocked = PAYWALL ? user.unlocked || false : true
+    return (
+      (forceScrape || isUnlocked) &&
+      (!user.tweetScrapeStarted || (!user.tweetScrapeCompleted && Date.now() - user.tweetScrapeStartedTime.getTime() > 1 * 60 * 1000))
+    )
   }
 
   const shouldRunWordwareAnalysis = (user: SelectUser, tweetScrapeCompleted: boolean): boolean => {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/53fde909-871b-43c8-967c-d919a4edcdb2)

TODO:
- [x] Finish the form so it works and scrapes any missing profiles and tweets without redirect
- [ ] Add this form to the bottom of the compatiblity results 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `NewPairFormBothNames` component for submitting and checking compatibility of two usernames.
	- Added a new section in the layout emphasizing username compatibility.
	- Included a new `PiXLogo` icon for improved visual appeal.

- **User Interface Improvements**
	- Enhanced header elements with additional text and emojis for better engagement.
	- Revised content for clarity and conciseness, improving overall readability and structure.

- **Logic Enhancements**
	- Improved response handling for username management functions, allowing for more flexible redirects based on conditions.
	- Enhanced compatibility analysis with refined logic that incorporates the pair's unlocked state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->