### PR TITLE
feat: add Xquik as an optional data fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ AI_MODEL=
 # Official X API v2 bearer token (pay-per-use). Primary data source.
 # https://developer.x.com
 X_API_BEARER_TOKEN=
+# Xquik API key. Optional fallback after the official X API.
+# https://xquik.com
+XQUIK_API_KEY=
 # SocialData API key — fallback scraper (https://socialdata.tools)
 SOCIALDATA_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The site went viral in 2024. This is the relaunched version: official X API for 
 ## How it works
 
 1. Enter a Twitter/X username (or two, for a compatibility check).
-2. The profile and ~15 recent posts are fetched via the official **X API v2** (SocialData as fallback) and cached in Neon Postgres.
+2. The profile and ~15 recent posts are fetched via the official **X API v2** (Xquik and SocialData as fallbacks) and cached in Neon Postgres.
 3. An LLM (default `xai/grok-4.20-non-reasoning`, via the **Vercel AI Gateway**) streams a structured analysis — roast, strengths, love life, spirit animal, pickup lines and more — straight into the page.
 4. The result is cached, shareable, and rendered into dynamic OG images.
 
@@ -19,6 +19,7 @@ The site went viral in 2024. This is the relaunched version: official X API for 
    - `AI_GATEWAY_API_KEY`: Vercel AI Gateway key (omit on Vercel — OIDC is automatic).
    - `AI_MODEL` (optional): any [Gateway model string](https://vercel.com/ai-gateway/models), e.g. `xai/grok-4.20-non-reasoning`, `zai/glm-5.2`, `openai/gpt-5.2`. Swapping models is just changing this var.
    - `X_API_BEARER_TOKEN`: official X API v2 bearer token (pay-per-use; buy credits in the [X developer console](https://developer.x.com)).
+   - `XQUIK_API_KEY`: optional [Xquik](https://xquik.com) fallback for profile and post reads.
    - `SOCIALDATA_API_KEY`: fallback scraper.
    - `NEXT_PUBLIC_BASE_URL`: base URL of the deployment — share links derive from it.
    - `NEXT_PUBLIC_POSTHOG_KEY`, `NEXT_PUBLIC_POSTHOG_HOST`: analytics (optional).
@@ -33,3 +34,5 @@ The site went viral in 2024. This is the relaunched version: official X API for 
 - **Brand**: Sauna tokens are defined in `tailwind.config.ts` + `src/app/globals.css`; official logo SVGs in `public/brand/`.
 
 Deployed on Vercel.
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-markdown": "^9.0.1",
         "remark-gfm": "^4.0.0",
         "secure-json-parse": "^2.7.0",
+        "server-only": "0.0.1",
         "sonner": "^2.0.7",
         "stripe": "^22.3.2",
         "tailwind-merge": "^2.4.0",
@@ -8542,6 +8543,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "next dev",
     "lint": "next lint",
     "start": "next start",
-    "stripe:listen": "stripe listen --forward-to localhost:3000/api/stripe/webhook"
+    "stripe:listen": "stripe listen --forward-to localhost:3000/api/stripe/webhook",
+    "test": "node --conditions=react-server --import tsx --test --test-concurrency=1 src/core/*.test.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -36,6 +37,7 @@
     "react-markdown": "^9.0.1",
     "remark-gfm": "^4.0.0",
     "secure-json-parse": "^2.7.0",
+    "server-only": "0.0.1",
     "sonner": "^2.0.7",
     "stripe": "^22.3.2",
     "tailwind-merge": "^2.4.0",

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -5,6 +5,7 @@ import { redirect } from 'next/navigation'
 
 import { scrapeTweets } from '@/core/logic'
 import { fetchProfileXApi } from '@/core/x-api'
+import { fetchProfileXquik, isXquikConfigured } from '@/core/xquik'
 import { getPair, getUser, insertPair, insertUser, unlockPair, unlockUser, updateUser } from '@/drizzle/queries'
 
 import { fetchUserDataBySocialData } from '../core/social-data'
@@ -21,17 +22,26 @@ export const handleNewUsername = async ({ username, redirectPath }: { username: 
 
   let { data, error } = await fetchProfileXApi({ username })
   if (!data) {
-    console.log(`[${username}] ⚠️ Profile X API (1/2)`, error)
+    console.log(`[${username}] ⚠️ Profile X API (1/3)`, error)
   } else {
-    console.log(`[${username}] ✅ Profile X API (1/2)`)
+    console.log(`[${username}] ✅ Profile X API (1/3)`)
+  }
+
+  if (!data && isXquikConfigured()) {
+    ;({ data, error } = await fetchProfileXquik({ username }))
+    if (!data) {
+      console.log(`[${username}] ⚠️ Profile Xquik (2/3)`, error)
+    } else {
+      console.log(`[${username}] ✅ Profile Xquik (2/3)`)
+    }
   }
 
   if (!data) {
     ;({ data, error } = await fetchUserDataBySocialData({ username }))
     if (!data) {
-      console.log(`[${username}] ⚠️ Profile SocialData (2/2)`, error)
+      console.log(`[${username}] ⚠️ Profile SocialData (3/3)`, error)
     } else {
-      console.log(`[${username}] ✅ Profile SocialData (2/2)`)
+      console.log(`[${username}] ✅ Profile SocialData (3/3)`)
     }
   }
 

--- a/src/core/logic.ts
+++ b/src/core/logic.ts
@@ -2,12 +2,14 @@ import 'server-only'
 
 import { fetchAndParseSocialDataTweets, fetchAndParseSocialDataTweetsByUsername } from './social-data'
 import { fetchProfileXApi, fetchTweetsXApi } from './x-api'
+import { fetchTweetsXquik, isXquikConfigured } from './xquik'
 
 /**
  * Tweet scraping orchestrator. Tiers:
  *   1. Official X API v2 (pay-per-use, primary)
- *   2. SocialData by user ID (fallback)
- *   3. SocialData by username search (fallback)
+ *   2. Xquik (optional fallback)
+ *   3. SocialData by user ID (fallback)
+ *   4. SocialData by username search (fallback)
  */
 export const scrapeTweets = async ({ twitterUserID, username }: { twitterUserID?: string; username: string }) => {
   console.log(`[${username}] twitterUserID:`, twitterUserID)
@@ -23,30 +25,41 @@ export const scrapeTweets = async ({ twitterUserID, username }: { twitterUserID?
     if (!userId) throw new Error('Could not resolve X user ID')
 
     const tweets = await fetchTweetsXApi({ userId, username })
-    console.log(`[${username}] ✅ X API Tweets: ${tweets.length} (1/3)`)
+    console.log(`[${username}] ✅ X API Tweets: ${tweets.length} (1/4)`)
     return { data: tweets, error: null }
   } catch (error) {
-    console.log(`[${username}] ⚠️ Error X API Tweets (Attempt 1/3)`, error)
+    console.log(`[${username}] ⚠️ Error X API Tweets (Attempt 1/4)`, error)
     // Continue to next method if this fails
+  }
+
+  if (isXquikConfigured()) {
+    try {
+      const tweets = await fetchTweetsXquik({ username })
+      console.log(`[${username}] ✅ Xquik Tweets: ${tweets.length} (2/4)`)
+      return { data: tweets, error: null }
+    } catch (error) {
+      console.log(`[${username}] ⚠️ Error Xquik Tweets (Attempt 2/4)`, error)
+      // Continue to the existing fallbacks if this fails
+    }
   }
 
   if (userId) {
     try {
       const tweets = await fetchAndParseSocialDataTweets(userId)
-      console.log(`[${username}] ✅ SocialData ID Tweets: ${tweets.length} (2/3)`)
+      console.log(`[${username}] ✅ SocialData ID Tweets: ${tweets.length} (3/4)`)
       return { data: tweets, error: null }
     } catch (error) {
-      console.log(`[${username}] ⚠️ Error SocialData ID Tweets (Attempt 2/3)`, error)
+      console.log(`[${username}] ⚠️ Error SocialData ID Tweets (Attempt 3/4)`, error)
       // Continue to next method if this fails
     }
   }
 
   try {
     const tweets = await fetchAndParseSocialDataTweetsByUsername(username)
-    console.log(`[${username}] ✅ SocialData Username Tweets: ${tweets.length} (3/3)`)
+    console.log(`[${username}] ✅ SocialData Username Tweets: ${tweets.length} (4/4)`)
     return { data: tweets, error: null }
   } catch (error) {
-    console.log(`[${username}] ⚠️ Error SocialData Tweets (Attempt 3/3)`, error)
+    console.log(`[${username}] ⚠️ Error SocialData Tweets (Attempt 4/4)`, error)
   }
 
   return {

--- a/src/core/social-data.test.ts
+++ b/src/core/social-data.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import { afterEach, describe, it } from 'node:test'
+
+import { fetchTweets, fetchTweetsByUsername, fetchUserDataBySocialData } from './social-data'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe('SocialData request URLs', () => {
+  it('keeps user input inside its intended path or query value', async () => {
+    const requestedUrls: string[] = []
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input)
+      requestedUrls.push(url)
+
+      if (new URL(url).pathname.endsWith('/tweets-and-replies') || new URL(url).pathname.endsWith('/search')) {
+        return new Response(JSON.stringify({ tweets: [] }))
+      }
+
+      return new Response(
+        JSON.stringify({
+          id_str: '123',
+          screen_name: 'example_user',
+          url: 'https://x.com/example_user',
+          name: 'Example User',
+          profile_image_url_https: 'https://images.example/avatar.jpg',
+          description: '',
+          location: '',
+          followers_count: 1,
+        }),
+      )
+    }) as typeof fetch
+
+    await fetchTweets('user/value?admin=true')
+    await fetchTweetsByUsername('alice&type=Top')
+    await fetchUserDataBySocialData({ username: 'profile/name?admin=true' })
+
+    assert.equal(new URL(requestedUrls[0]).pathname, '/twitter/user/user%2Fvalue%3Fadmin%3Dtrue/tweets-and-replies')
+
+    const searchUrl = new URL(requestedUrls[1])
+    assert.equal(searchUrl.searchParams.get('query'), 'from:alice&type=Top -filter:replies')
+    assert.equal(searchUrl.searchParams.get('type'), 'Latest')
+    assert.equal([...searchUrl.searchParams].length, 2)
+
+    assert.equal(new URL(requestedUrls[2]).pathname, '/twitter/user/profile%2Fname%3Fadmin%3Dtrue')
+  })
+})

--- a/src/core/social-data.ts
+++ b/src/core/social-data.ts
@@ -52,7 +52,7 @@ type SocialDataTweet = {
 }
 
 export async function fetchTweets(userId: string) {
-  const url = `https://api.socialdata.tools/twitter/user/${userId}/tweets-and-replies`
+  const url = `https://api.socialdata.tools/twitter/user/${encodeURIComponent(userId)}/tweets-and-replies`
 
   try {
     const response = await fetch(url, {
@@ -101,7 +101,11 @@ export async function fetchAndParseSocialDataTweets(userId: string): Promise<Twe
 }
 
 export async function fetchTweetsByUsername(username: string) {
-  const url = `https://api.socialdata.tools/twitter/search?query=from%3A${username}%20-filter%3Areplies&type=Latest`
+  const params = new URLSearchParams({
+    query: `from:${username} -filter:replies`,
+    type: 'Latest',
+  })
+  const url = `https://api.socialdata.tools/twitter/search?${params}`
 
   try {
     const response = await fetch(url, {
@@ -153,7 +157,7 @@ export async function fetchUserDataBySocialData({ username }: { username: string
   data: DatabaseUser | null
   error: string | null
 }> {
-  const url = `https://api.socialdata.tools/twitter/user/${username}`
+  const url = `https://api.socialdata.tools/twitter/user/${encodeURIComponent(username)}`
 
   try {
     const response = await fetch(url, {

--- a/src/core/xquik.test.ts
+++ b/src/core/xquik.test.ts
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict'
+import { afterEach, describe, it } from 'node:test'
+
+import { fetchProfileXquik, fetchTweetsXquik, isXquikConfigured } from './xquik'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  delete process.env.XQUIK_API_KEY
+  globalThis.fetch = originalFetch
+})
+
+describe('Xquik data source', () => {
+  it('sends the current contract and maps original posts', async () => {
+    process.env.XQUIK_API_KEY = '  xq_test_key  '
+    let request: { input: RequestInfo | URL; init?: RequestInit } | undefined
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      request = { input, init }
+      return new Response(
+        JSON.stringify({
+          tweets: [
+            {
+              author: { username: 'example_user' },
+              createdAt: '2026-07-29T10:00:00Z',
+              entities: {
+                urls: [{ url: 'https://t.co/link', expanded_url: 'https://example.com/article' }],
+              },
+              likeCount: 4,
+              quoteCount: 1,
+              replyCount: 2,
+              retweetCount: 3,
+              text: 'Read https://t.co/link',
+              viewCount: 5,
+            },
+            {
+              isReply: true,
+              text: 'Filtered reply',
+            },
+            {
+              retweeted_tweet: { id: '1' },
+              text: 'Filtered repost',
+            },
+          ],
+        }),
+      )
+    }) as typeof fetch
+
+    const tweets = await fetchTweetsXquik({ username: '@example_user' })
+
+    assert.deepEqual(tweets, [
+      {
+        isRetweet: false,
+        author: { userName: 'example_user' },
+        createdAt: '2026-07-29T10:00:00Z',
+        text: 'Read https://example.com/article',
+        retweetCount: 3,
+        replyCount: 2,
+        likeCount: 4,
+        quoteCount: 1,
+        viewCount: 5,
+      },
+    ])
+    assert.ok(request)
+
+    const url = new URL(String(request.input))
+    assert.equal(url.pathname, '/api/v1/x/tweets/search')
+    assert.equal(url.searchParams.get('q'), 'from:example_user')
+    assert.equal(url.searchParams.get('fromUser'), 'example_user')
+    assert.equal(url.searchParams.get('replies'), 'exclude')
+    assert.equal(url.searchParams.get('retweets'), 'exclude')
+    assert.equal(url.searchParams.get('limit'), '20')
+    assert.equal(url.searchParams.get('queryType'), 'Latest')
+
+    const headers = new Headers(request.init?.headers)
+    assert.equal(headers.get('x-api-key'), 'xq_test_key')
+    assert.equal(headers.get('xquik-api-contract'), '2026-04-29')
+    assert.equal(request.init?.cache, 'no-store')
+  })
+
+  it('maps profiles into the cached application shape', async () => {
+    process.env.XQUIK_API_KEY = 'xq_test_key'
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          id: '123',
+          username: 'example_user',
+          name: 'Example User',
+          profilePicture: 'https://images.example/avatar_normal.jpg',
+          description: 'Builder',
+          location: 'Internet',
+          followers: 42,
+        }),
+      )) as typeof fetch
+
+    const result = await fetchProfileXquik({ username: 'example_user' })
+
+    assert.equal(result.error, null)
+    assert.deepEqual(result.data, {
+      username: 'example_user',
+      url: 'https://x.com/example_user',
+      name: 'Example User',
+      profilePicture: 'https://images.example/avatar_400x400.jpg',
+      description: 'Builder',
+      location: 'Internet',
+      fullProfile: {
+        twitterUserID: '123',
+        id: '123',
+        username: 'example_user',
+        name: 'Example User',
+        profilePicture: 'https://images.example/avatar_normal.jpg',
+        description: 'Builder',
+        location: 'Internet',
+        followers: 42,
+      },
+      followers: 42,
+    })
+  })
+
+  it('skips malformed handles before calling the API', async () => {
+    process.env.XQUIK_API_KEY = 'xq_test_key'
+    let fetchCalled = false
+    globalThis.fetch = (async () => {
+      fetchCalled = true
+      return new Response()
+    }) as typeof fetch
+
+    await assert.rejects(fetchTweetsXquik({ username: 'user -filter:replies' }), /Invalid X username/)
+    assert.equal(fetchCalled, false)
+    assert.equal(isXquikConfigured(), true)
+  })
+})

--- a/src/core/xquik.ts
+++ b/src/core/xquik.ts
@@ -1,0 +1,170 @@
+import 'server-only'
+
+import type { DatabaseUser, TweetType } from '../types'
+
+const XQUIK_API_BASE = 'https://xquik.com/api/v1'
+const XQUIK_API_CONTRACT = '2026-04-29'
+const MAX_TWEETS = 15
+
+type XquikUrlEntity = {
+  expanded_url?: string
+  url?: string
+}
+
+type XquikTweet = {
+  author?: {
+    username?: string
+  }
+  createdAt?: string
+  entities?: {
+    urls?: XquikUrlEntity[]
+  }
+  inReplyToId?: string
+  isReply?: boolean
+  likeCount?: number
+  quoteCount?: number
+  replyCount?: number
+  retweetCount?: number
+  retweeted_tweet?: object | null
+  text: string
+  type?: string
+  viewCount?: number
+}
+
+type XquikTweetSearchResponse = {
+  tweets?: XquikTweet[]
+}
+
+type XquikUser = {
+  description?: string
+  followers?: number
+  id: string
+  location?: string
+  name: string
+  profilePicture?: string
+  username: string
+}
+
+const getApiKey = (): string => process.env.XQUIK_API_KEY?.trim() ?? ''
+
+const normalizeUsername = (username: string): string => {
+  const normalized = username.replace(/^@/, '').trim()
+  if (!/^[A-Za-z0-9_]{1,15}$/.test(normalized)) {
+    throw new Error(`Invalid X username: ${username}`)
+  }
+  return normalized
+}
+
+const expandTweetText = (tweet: XquikTweet): string => {
+  let text = tweet.text
+  for (const entity of tweet.entities?.urls ?? []) {
+    if (entity.url && entity.expanded_url) {
+      text = text.replaceAll(entity.url, entity.expanded_url)
+    }
+  }
+  return text
+}
+
+const isRetweet = (tweet: XquikTweet): boolean => tweet.type === 'retweet' || (tweet.retweeted_tweet !== undefined && tweet.retweeted_tweet !== null)
+
+const xquikFetch = async <T>(path: string, params: Record<string, string | number> = {}): Promise<T> => {
+  const apiKey = getApiKey()
+  if (!apiKey) {
+    throw new Error('XQUIK_API_KEY is not set')
+  }
+
+  const url = new URL(`${XQUIK_API_BASE}${path}`)
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, String(value))
+  }
+
+  const response = await fetch(url, {
+    cache: 'no-store',
+    headers: {
+      Accept: 'application/json',
+      'x-api-key': apiKey,
+      'xquik-api-contract': XQUIK_API_CONTRACT,
+    },
+    signal: AbortSignal.timeout(15_000),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Xquik API request failed with status ${response.status}`)
+  }
+
+  return response.json() as Promise<T>
+}
+
+export const fetchTweetsXquik = async ({ username }: { username: string }): Promise<TweetType[]> => {
+  const normalizedUsername = normalizeUsername(username)
+  const result = await xquikFetch<XquikTweetSearchResponse>('/x/tweets/search', {
+    fromUser: normalizedUsername,
+    limit: 20,
+    q: `from:${normalizedUsername}`,
+    queryType: 'Latest',
+    replies: 'exclude',
+    retweets: 'exclude',
+  })
+
+  const tweets = (result.tweets ?? [])
+    .filter((tweet) => !tweet.isReply && !tweet.inReplyToId && !isRetweet(tweet))
+    .map((tweet) => ({
+      isRetweet: false,
+      author: {
+        userName: tweet.author?.username ?? normalizedUsername,
+      },
+      createdAt: tweet.createdAt ?? '',
+      text: expandTweetText(tweet),
+      retweetCount: tweet.retweetCount ?? 0,
+      replyCount: tweet.replyCount ?? 0,
+      likeCount: tweet.likeCount ?? 0,
+      quoteCount: tweet.quoteCount ?? 0,
+      viewCount: tweet.viewCount ?? 0,
+    }))
+    .slice(0, MAX_TWEETS)
+
+  if (tweets.length === 0) {
+    throw new Error(`Xquik returned no original posts for ${normalizedUsername}`)
+  }
+
+  return tweets
+}
+
+export const fetchProfileXquik = async ({
+  username,
+}: {
+  username: string
+}): Promise<{
+  data: DatabaseUser | null
+  error: string | null
+}> => {
+  try {
+    const normalizedUsername = normalizeUsername(username)
+    const user = await xquikFetch<XquikUser>(`/x/users/${encodeURIComponent(normalizedUsername)}`)
+
+    return {
+      data: {
+        username: user.username,
+        url: `https://x.com/${user.username}`,
+        name: user.name,
+        profilePicture: (user.profilePicture ?? '').replace('_normal.', '_400x400.'),
+        description: user.description ?? '',
+        location: user.location ?? '',
+        fullProfile: {
+          twitterUserID: user.id,
+          ...user,
+        },
+        followers: user.followers ?? 0,
+      },
+      error: null,
+    }
+  } catch (error) {
+    console.error(`Error fetching Xquik profile for ${username}:`, error)
+    return {
+      data: null,
+      error: error instanceof Error ? error.message : 'No profile found',
+    }
+  }
+}
+
+export const isXquikConfigured = (): boolean => getApiKey().length > 0


### PR DESCRIPTION
## Summary

Rebuild the integration on the current Sauna relaunch architecture.

- Keep the official X API v2 as the primary profile and post source.
- Use Xquik as an optional fallback when `XQUIK_API_KEY` is set.
- Preserve both existing SocialData fallback paths.
- Keep existing behavior unchanged when Xquik is not configured.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.

## Xquik Integration

- Read profiles through `GET /api/v1/x/users/{id}`.
- Read recent original posts through `GET /api/v1/x/tweets/search`.
- Send the current `2026-04-29` API contract header.
- Authenticate only on the server with `x-api-key`.
- Reject malformed handles before building search queries.
- Exclude replies and reposts in the request and response mapping.
- Expand returned `t.co` links for analysis fidelity.
- Map results into the existing `DatabaseUser` and `TweetType` contracts.
- Fall through after errors or empty post results.
- Document the optional key in `.env.example` and the README.

## Independent Repository Fix

Encode user IDs and usernames in existing SocialData paths. Build its search query with `URLSearchParams`. Reserved characters can no longer change path or query boundaries.

Regression coverage verifies the hardened URLs and fallback mapping.

## Validation

- `npm ci`
- `npm test` - 4 tests pass
- `npm run lint` - passes with existing repository warnings
- `npx tsc --noEmit`
- `STRIPE_SECRET_KEY=sk_test_dummy npm run build:old`
- Prettier check for every changed file
- `git diff --check`

The Vercel preview requires Wordware team authorization. That external gate needs maintainer approval.
