### PR TITLE
Fix compatibility page 404 when pair row is missing

### DIFF
--- a/src/app/[username]/[usernamePair]/page.tsx
+++ b/src/app/[username]/[usernamePair]/page.tsx
@@ -7,7 +7,7 @@ import { PiPlus } from 'react-icons/pi'
 import { ProfileHighlight } from '@/components/analysis/profile-highlight'
 import NewPairFormBothNames from '@/components/new-pair-form-both-names'
 import Topbar from '@/components/top-bar'
-import { getPair, getUser } from '@/drizzle/queries'
+import { getPair, getUser, insertPair } from '@/drizzle/queries'
 
 import PairComponent from '../../../components/analysis/pair-component'
 
@@ -16,12 +16,24 @@ const PairPage = async ({ params }: { params: Promise<{ username: string; userna
   console.log('Page for', username, 'and', usernamePair)
   //ALWAYS SORT THE USER IDS SO WE CAN USE THEM AS KEYS
   const [username1, username2] = [username, usernamePair].sort()
-  const pair = await getPair({ usernames: [username1, username2] })
+  let pair = await getPair({ usernames: [username1, username2] })
 
-  // User pairs have to have been created before getting to this page
   const [user1, user2] = await Promise.all([getUser({ username: username1 }), getUser({ username: username2 })])
 
-  if (!user1 || !user2 || !pair) return <div>Pair does not exist</div>
+  if (!user1 || !user2) return <div>Pair does not exist</div>
+
+  // Self-heal: when both users exist but the pair row doesn't (direct URL
+  // visit, or the creation flow was interrupted), create it on the fly
+  if (!pair) {
+    try {
+      await insertPair({ usernames: [username1, username2] })
+    } catch {
+      // lost a race with a concurrent visitor — the row exists now
+    }
+    pair = await getPair({ usernames: [username1, username2] })
+  }
+
+  if (!pair) return <div>Pair does not exist</div>
 
   return (
     <div className="flex-center relative min-h-screen w-full flex-col gap-12 bg-desk px-4 py-28 sm:px-12 md:px-28 md:pt-24">
@@ -71,13 +83,15 @@ export async function generateMetadata({
   const [user1, user2] = await Promise.all([getUser({ username: username1 }), getUser({ username: username2 })])
   const pair = await getPair({ usernames: [username1, username2] })
 
-  if (!user1 || !user2 || !pair) return notFound()
+  // Only 404 when a user is missing — a missing pair row is self-healed by the
+  // page component, so metadata must not kill the request before that happens
+  if (!user1 || !user2) return notFound()
 
   const imageParams = new URLSearchParams()
   const section = (await searchParams).section || 'about'
   // const section = 'about' //TODO: Hardcode about for now, to make it dynamic we need to design the full OG image
   // generator for all the section types
-  const content = (pair.analysis as any)?.[section]
+  const content = (pair?.analysis as any)?.[section]
 
   imageParams.set('name1', user1.name || '')
   imageParams.set('username1', user1.username || '')

--- a/src/app/api/analysis/pair/route.ts
+++ b/src/app/api/analysis/pair/route.ts
@@ -4,6 +4,7 @@ import { getPair, getUser, updatePair } from '@/drizzle/queries'
 import { AI_MODEL } from '@/lib/ai'
 import { parseJsonLoose } from '@/lib/parse-json-loose'
 import { compatibilityPrompt, formatTweetsMarkdown } from '@/lib/prompts'
+import { compatibilitySchema } from '@/lib/schemas'
 import { TweetType } from '@/types'
 
 /**
@@ -40,6 +41,8 @@ export async function POST(request: Request) {
   const tweetsMarkdown2 = formatTweetsMarkdown(user2.tweets as TweetType[], user2.username)
 
   const { system, prompt } = compatibilityPrompt({
+    name1: user1.name || user1.username,
+    name2: user2.name || user2.username,
     profileInfo1: JSON.stringify(user1.fullProfile),
     tweetsMarkdown1,
     profileInfo2: JSON.stringify(user2.fullProfile),
@@ -74,6 +77,12 @@ export async function POST(request: Request) {
     onEnd: async ({ text }) => {
       try {
         const output = parseJsonLoose(text)
+        // Plain-text mode can occasionally drop a key — log it for observability
+        // (the UI skips missing cards gracefully)
+        const check = compatibilitySchema.safeParse(output)
+        if (!check.success) {
+          console.warn(`[${pair.user1lowercaseUsername}, ${pair.user2lowercaseUsername}] ⚠️ Output shape issues:`, check.error.issues.map((i) => i.path.join('.')).join(', '))
+        }
         await updatePair({
           pair: {
             ...pair,

--- a/src/app/api/analysis/route.ts
+++ b/src/app/api/analysis/route.ts
@@ -4,6 +4,7 @@ import { getUser, updateUser } from '@/drizzle/queries'
 import { AI_MODEL } from '@/lib/ai'
 import { parseJsonLoose } from '@/lib/parse-json-loose'
 import { formatTweetsMarkdown, fullPrompt, roastPrompt } from '@/lib/prompts'
+import { fullSchema, roastSchema } from '@/lib/schemas'
 import { TweetType, TwitterAnalysis } from '@/types'
 
 /**
@@ -73,6 +74,11 @@ export async function POST(request: Request) {
     onEnd: async ({ text }) => {
       try {
         const output = parseJsonLoose(text)
+        // Plain-text mode can occasionally drop a key — log it for observability
+        const check = (full ? fullSchema : roastSchema).safeParse(output)
+        if (!check.success) {
+          console.warn(`[${user.username}] ⚠️ Output shape issues:`, check.error.issues.map((i) => i.path.join('.')).join(', '))
+        }
         // Include the fresh started time: spreading the pre-generation `user`
         // would write the old timestamp back, making a just-regenerated
         // analysis still look stale to refreshStaleUser (regeneration loop)

--- a/src/components/new-pair-form.tsx
+++ b/src/components/new-pair-form.tsx
@@ -33,9 +33,10 @@ const NewPairForm = () => {
       toast.error('You cannot pair with yourself')
       return
     }
+    // No redirectPath here: handleNewUsername's redirect() would navigate away
+    // before handlePair could create the pair row, 404ing the pair page
     const response = await handleNewUsername({
       username: cleanedUsername,
-      redirectPath: `${pathname}/${cleanedUsername}`,
     })
 
     if (response?.error) {

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -137,11 +137,15 @@ Return a JSON object with EXACTLY these keys and no others:
 }
 
 export function compatibilityPrompt({
+  name1,
+  name2,
   profileInfo1,
   tweetsMarkdown1,
   profileInfo2,
   tweetsMarkdown2,
 }: {
+  name1: string
+  name2: string
   profileInfo1: string
   tweetsMarkdown1: string
   profileInfo2: string
@@ -231,13 +235,13 @@ After understanding each, answer the following questions for each person.
 Give answers to each section and provide reasoning. Respond in 2-3 sentences. Keep it concise. Make to act like a horoscope teller, because that's what people pay for. Explain your assumptions. Don't focus your assumptions on personality types.
 
 **Inputs:**
-Profile 1:
+${name1}'s profile:
 
 ${profileInfo1}
 
 ${tweetsMarkdown1}
 
-Profile 2:
+${name2}'s profile:
 
 ${profileInfo2}
 
@@ -247,7 +251,7 @@ Output the result as valid JSON, strictly adhering to the defined schema. Ensure
 
 You can **bold** important information within the strings.
 
-Refer to the profiles by their name and respond in the most commonly used language of their tweets.
+Refer to the profiles by their name and respond in the most commonly used language of their tweets. ALWAYS call the two people **${name1}** and **${name2}** in the text you write — NEVER "Profile 1", "Profile 2", "person one", "the first person" or similar. (The JSON keys "profile1" and "profile2" stay as keys: profile1 = ${name1}, profile2 = ${name2}.)
 
 Return a JSON object with EXACTLY these keys and no others:
 "mbti" (object: { "profile1": string, "profile2": string }), "about" (string), "crazy" (string), "drama" (string), "emojis" (string), "divorce" (string), "marriage" (string), "3rd_wheel" (string), "free_time" (string), "red_flags" (object: { "profile1": array of strings, "profile2": array of strings }), "dealbreaker" (string), "green_flags" (object: { "profile1": array of strings, "profile2": array of strings }), "follower_flex" (string), "risk_appetite" (string), "love_languages" (string), "secret_desires" (string), "friends_forever" (string), "jealousy_levels" (string), "attachment_style" (string), "values_alignment" (string), "breakup_percentage" (string), "overall_compatibility" (string), "personality_type_match" (string), "emotional_compatibility" (string), "financial_compatibility" (string), "communication_style_compatibility" (string)`


### PR DESCRIPTION
## Bug
https://twitter.wordware.ai/kozerafilip/bertie_ai 404'd. Production DB showed both users scraped successfully but **no pair row**.

## Root cause (present since the original codebase)
`new-pair-form.tsx` (the pair form on results pages) passed `redirectPath` into `handleNewUsername`. That action calls `redirect()` — which throws `NEXT_REDIRECT` — as soon as the partner profile exists, so the subsequent `handlePair` (the only thing that inserts the pair row) **never executed**. The visitor landed on a pair URL with no pair row, and `generateMetadata`'s `notFound()` turned it into a 404.

## Fix (two layers)
1. The form no longer passes `redirectPath`; navigation happens via `handlePair({shouldRedirect: true})` after the row exists.
2. The pair page **self-heals**: if both users exist but the pair row doesn't (direct URL visit, interrupted flow, old broken links), it inserts the row on the fly (race-safe) and renders. `generateMetadata` only 404s when a *user* is missing.

## Verified
Deleted a pair row on the Neon preview branch, visited the URL: row recreated, page rendered, generation pipeline proceeds as normal. `tsc` + `next build` clean.

Fixes the reported URL for anyone who retries it after deploy — the visit itself will create the pair and kick off the analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)